### PR TITLE
Fix no events delete error

### DIFF
--- a/archiver/delete.py
+++ b/archiver/delete.py
@@ -36,7 +36,11 @@ def delete_events(psql_conn, s3bucket):
     """
     Finds which events we already have archives for, and deletes them
     """
-    archive_date = get_oldest_event_timestamp(psql_conn).date()
+    oldest = get_oldest_event_timestamp(psql_conn)
+    if not oldest:
+        return
+
+    archive_date = oldest.date()
     database_dates = set()
     while archive_date <= date.today() - timedelta(days=settings.RETENTION_DAYS):
         database_dates.add(archive_date)

--- a/archiver/test_delete.py
+++ b/archiver/test_delete.py
@@ -87,3 +87,14 @@ class TestArchiver(TestCase):
             cur.execute("SELECT count(*) from events")
             [count] = cur.fetchone()
             self.assertEqual(count, 1)
+
+    @mock_s3
+    def test_delete_with_no_events(self):
+        """
+        Should not raise any exceptions when there is no events to delete
+        """
+
+        client = boto3.resource("s3")
+        bucket = client.create_bucket(Bucket="rasa-archive")
+
+        delete_events(self.conn, bucket)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[tool.black]
+line-length = 88
+include = '\.pyi?$'
+exclude = '''
+/(
+    \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | \.ve
+  | ve
+  | env
+  | _build
+  | buck-out
+  | build
+  | dist
+  | migrations
+)/
+'''

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,11 +1,13 @@
 [flake8]
 max-line-length = 88
+exclude = ve/*,env/
 
 [isort]
 line_length = 88
 # Vertical hanging indent, for black
 multi_line_output = 3
 include_trailing_comma = True
+skip = ve/,env/
 
 [coverage:run]
 branch = True


### PR DESCRIPTION
Error this PR fixes:
```
  File "rasa-postgres-archiver/archiver/delete.py", line 39, in delete_events
    archive_date = get_oldest_event_timestamp(psql_conn).date()
AttributeError: 'NoneType' object has no attribute 'date'
```

Happens because there isn't any traffic on the RASA app